### PR TITLE
To fix bug where position was created without startup._id,

### DIFF
--- a/src/components/startup-components/startup-profile-startups.js
+++ b/src/components/startup-components/startup-profile-startups.js
@@ -145,7 +145,9 @@ class StartupProfile extends Component {
       virtual: false,
       inperson: false,
     };
-    this.props.createPost(newPost, this.props.startup, this.props.history);
+    if (this.props.startup?._id) {
+      this.props.createPost(newPost, this.props.startup, this.props.history);
+    } 
   }
 
   handleApprovedToggle(checked) {


### PR DESCRIPTION
add if statement to check that startup._id is not null before creating position

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Documentation update

