### PR TITLE
Attempting to fix "actively searching" input lost during merging

### DIFF
--- a/src/components/student-components/student-profile.js
+++ b/src/components/student-components/student-profile.js
@@ -626,7 +626,7 @@ class StudentProfile extends Component {
 
             <div className="input-activity">
               <div className="input-title">Actively Searching?</div>
-              <div>Shows startups you are actively looking at this platform.</div>
+              <div> Shows startups you are actively looking at this platform. </div>
               <Switch onChange={this.studentStatusChange} checked={this.state.student.job_search_status === 'Active'} />
             </div>
           </div>


### PR DESCRIPTION
After merging, while the actively searching slider remains for startups and it remains stored in the DB, students can't alter their status as the input was accidentally removed. Attempting to fix.